### PR TITLE
Add tooltip support to Svg Elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,17 @@ node_modules/
 package.json
 package-lock.json
 webpack.config.js
+.project
+.settings
+.classpath
+.npmrc
+.pnpmfile.cjs
+svg-demo/frontend/generated
+svg-demo/frontend/index.html
+svg-demo/src/main/dev-bundle
+tsconfig.json
+types.d.ts
+vite.config.ts
 
 # ignore db folder
 db/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.componentfactory</groupId>
 	<artifactId>svg-root</artifactId>
-	<version>1.2.1</version>
+	<version>2.0.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Svg Root</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<packaging>pom</packaging>
 	<name>Svg Root</name>
-	<description>Integration of vcf-svg for Vaadin platform 23</description>
+	<description>Integration of vcf-svg for Vaadin platform 24</description>
 
 	<inceptionYear>2020</inceptionYear>
 	<organization>

--- a/svg-demo/pom.xml
+++ b/svg-demo/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>svg-demo</artifactId>
-    <version>1.2.1</version>
+    <version>2.0.0-SNAPSHOT</version>
     <inceptionYear>2020</inceptionYear>
 
     <name>Svg Demo</name>

--- a/svg-demo/pom.xml
+++ b/svg-demo/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>svg</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- Added to provide logging output as Flow uses -->
         <!-- the unbound SLF4J no-operation (NOP) logger implementation -->

--- a/svg-demo/src/main/java/com/vaadin/flow/component/svg/vaadincom/SvgView.java
+++ b/svg-demo/src/main/java/com/vaadin/flow/component/svg/vaadincom/SvgView.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.component.svg.elements.Rect;
 import com.vaadin.flow.component.svg.elements.Text;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +49,6 @@ public class SvgView extends DemoView {
     }
 
     private void basicDemo() {
-
         // begin-source-example
         // source-example-heading: Basic Demo
         Svg draw = new Svg();
@@ -73,13 +71,15 @@ public class SvgView extends DemoView {
                 Notification.show("Mo Element clicked");
             }
         });
+        
+        draw.setTitle("I'm the title for the circle", circle.getId());
+
         // end-source-example
 
         addCard("Basic Demo", draw);
     }
 
     private void complexDemo() {
-
         // begin-source-example
         // source-example-heading: Complex Demo
         VerticalLayout demoContainer = new VerticalLayout();
@@ -178,6 +178,10 @@ public class SvgView extends DemoView {
         svg.add(image);
 
         demoContainer.add(svg);
+        
+        svg.setTitle("I'm the title for the ellipse1", "ellipse1");
+        svg.setTitle("I'm tooltip for the line", "line");
+        svg.setTitle("I'm title for the path", "path");  
 
         //Add control buttons
         zoomControlButtons.add(new Button("Toggle Zoom", e -> {
@@ -274,6 +278,5 @@ public class SvgView extends DemoView {
         // end-source-example
         addCard("Complex Demo", demoContainer);
     }
-
 
 }

--- a/svg/pom.xml
+++ b/svg/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>svg</artifactId>
-    <version>1.2.1</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Svg Component</name>
 

--- a/svg/src/main/java/com/vaadin/flow/component/svg/Svg.java
+++ b/svg/src/main/java/com/vaadin/flow/component/svg/Svg.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
  * elements as well as listen to events on said elements.
  */
 @Tag("vcf-svg")
-@NpmPackage(value = "@vaadin-component-factory/vcf-svg", version = "24.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-svg", version = "24.1.0")
 @JsModule("@vaadin-component-factory/vcf-svg/src/vcf-svg.js")
 public class Svg extends Component implements HasSize, HasStyle {
 

--- a/svg/src/main/java/com/vaadin/flow/component/svg/Svg.java
+++ b/svg/src/main/java/com/vaadin/flow/component/svg/Svg.java
@@ -409,5 +409,15 @@ public class Svg extends Component implements HasSize, HasStyle {
     protected Optional<SvgElement> findElementForId(String elementId) {
         return svgElements.stream().filter(element -> elementId.equals(element.getId())).findFirst();
     }
-
+    
+    /**
+     * Sets title(tooltip) to the svgElement with the given id.
+     * 
+     * @param titleText title text to set
+     * @param parentElementId svgElement id to set title to
+     */
+    public void setTitle(String titleText, String parentElementId) {
+      getElement().executeJs("return;")
+          .then((x) -> getElement().callJsFunction("_setTitle", titleText, parentElementId));
+    }
 }


### PR DESCRIPTION
~~Depends on new release of web-component part, version 24.1.0: https://github.com/vaadin-component-factory/vcf-svg/pull/7~~

Update: 
Web-component part 24.1.0 released, see https://www.npmjs.com/package/@vaadin-component-factory/vcf-svg/v/24.1.0